### PR TITLE
Add the build of all architectures to github actions

### DIFF
--- a/.github/workflows/buildTests.yaml
+++ b/.github/workflows/buildTests.yaml
@@ -2,6 +2,10 @@ name: build tests for flannel-cni
 
 on: [push, pull_request]
 
+env:
+  GO_VERSION: "1.15.15"
+  LINUX_ARCHES: "amd64 386 arm arm64 s390x mips64le ppc64le"
+
 jobs:
   build:
     name: build
@@ -10,7 +14,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.15
+        go-version: ${{ env.GO_VERSION }}
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
 
@@ -18,7 +22,14 @@ jobs:
       run: go mod vendor
 
     - name: build linux
-      run: make build_linux
+      run: |
+        set -e
+        for arch in ${LINUX_ARCHES}; do
+          echo "Building for arch $arch"
+          ARCH=$arch make build_linux
+          file bin/flannel-$arch
+          rm bin/*
+        done
 
     - name: build windows
       run: make build_windows
@@ -34,7 +45,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15.15
+        go-version: ${{ env.GO_VERSION }}
 
     - run: go version
 

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ dist/flannel-$(TAG)-$(ARCH).docker: dist/flannel-$(ARCH)
 #	docker save -o dist/flannel-$(TAG)-$(ARCH).docker $(REGISTRY):$(TAG)-$(ARCH)
 
 build_linux:
-	GOOS=linux scripts/build_flannel.sh
+	GOOS=linux GOARCH=$(ARCH) scripts/build_flannel.sh
 
 build_windows:
 	GOOS=windows scripts/build_flannel.sh

--- a/scripts/build_flannel.sh
+++ b/scripts/build_flannel.sh
@@ -3,14 +3,15 @@ set -e
 cd $(dirname "$0")/..
 
 export GOOS="${GOOS:-linux}"
+export GOARCH="${GOARCH:-amd64}"
 export GOFLAGS="${GOFLAGS} -mod=vendor"
 
 mkdir -p "${PWD}/bin"
 
-echo "Building flannel for $GOOS"
+echo "Building flannel for ${GOOS} in ${GOARCH}"
 
 if [ "$GOOS" == "linux" ]; then
-    go build -o "${PWD}/bin/flannel" "$@" .
+    go build -o "${PWD}/bin/flannel-${GOARCH}" "$@" .
 else
     go build -o "${PWD}/bin/flannel.exe" "$@" .
 fi


### PR DESCRIPTION
Tested and works:

```
Building for arch amd64
GOOS=linux GOARCH=amd64 scripts/build_flannel.sh
Building flannel for linux in amd64
bin/flannel-amd64: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, Go BuildID=XHLlVjZVFg_x9ig30cN4/8SHGiU-zVAHiOqFuCCjJ/cESwNLKfnBYddxBGODD9/qnH0fVVM-tTRA42WrITk, not stripped
Building for arch 386
GOOS=linux GOARCH=386 scripts/build_flannel.sh
Building flannel for linux in 386
bin/flannel-386: ELF 32-bit LSB executable, Intel 80386, version 1 (SYSV), statically linked, Go BuildID=51lkx3H_Tk9yNj1-ap3h/Pwb8eS7kiIQYVAndJZ--/KvTwlG1dQKTdpuBYueda/i_LlpUO5aHVX_GMeSEM0, not stripped
Building for arch arm
GOOS=linux GOARCH=arm scripts/build_flannel.sh
Building flannel for linux in arm
bin/flannel-arm: ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, Go BuildID=qnS4ht7pGy_bKfuEovnR/VhkoiTle1_CQoNNWmgSV/KjkfOxG78l52aaSEIHbj/Sv9d63MEYZTfnYGwri8H, not stripped
Building for arch arm64
GOOS=linux GOARCH=arm64 scripts/build_flannel.sh
Building flannel for linux in arm64
bin/flannel-arm64: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=ZXuBkleVBy94s9eFsAGc/jqrdPO1Q-Kph1oEQ6nxT/UQBFMVX7ZYto_dWg-LA1/mzXZavzL1oWj2GdXA3mg, not stripped
Building for arch s390x
GOOS=linux GOARCH=s390x scripts/build_flannel.sh
Building flannel for linux in s390x
bin/flannel-s390x: ELF 64-bit MSB executable, IBM S/390, version 1 (SYSV), statically linked, Go BuildID=drC5r0K0ZydS6CrcPN38/fo-MnUd385ghdYn1pDBk/8JpZv0Iq2pJbt0m-Zc5p/JD0LPJBM9zcA5qS4wH41, not stripped
Building for arch mips64le
GOOS=linux GOARCH=mips64le scripts/build_flannel.sh
Building flannel for linux in mips64le
bin/flannel-mips64le: ELF 64-bit LSB executable, MIPS, MIPS-III version 1 (SYSV), statically linked, Go BuildID=zGLFhxcx1Q-vCSmQl_fQ/B9pVq_Tww1Pd_K2ho59e/cYSRMvA2uRg5m2aiV6pJ/sG1cichMYh12-8OgIMtW, not stripped
Building for arch ppc64le
GOOS=linux GOARCH=ppc64le scripts/build_flannel.sh
Building flannel for linux in ppc64le
bin/flannel-ppc64le: ELF 64-bit LSB executable, 64-bit PowerPC or cisco 7500, version 1 (SYSV), statically linked, Go BuildID=fj4_PYzJ0imXJ8nw6Mgy/YmeFdPJX3SBdCsiAElSi/G-v35pfZ5VMRyZ-OuUbb/ZuF6ONCDqsARjTYeHhgC, not stripped
```

Signed-off-by: Manuel Buil <mbuil@suse.com>