### PR TITLE
Fix FLANNEL_IPMASQ bug

### DIFF
--- a/flannel_linux.go
+++ b/flannel_linux.go
@@ -80,8 +80,7 @@ func doCmdAdd(args *skel.CmdArgs, n *NetConf, fenv *subnetEnv) error {
 	}
 
 	if !hasKey(n.Delegate, "ipMasq") {
-		// if flannel is not doing ipmasq, we should
-		ipmasq := !*fenv.ipmasq
+		ipmasq := *fenv.ipmasq
 		n.Delegate["ipMasq"] = ipmasq
 	}
 


### PR DESCRIPTION
This fixes a bug where FLANNEL_IPMASQ=true is currently propagated to CNI Bridge as false because we are always negating the value.

This PR fixes that

Signed-off-by: Manuel Buil <mbuil@suse.com>