### PR TITLE
Fix some errors thrown by lint tool

### DIFF
--- a/flannel_linux.go
+++ b/flannel_linux.go
@@ -118,7 +118,7 @@ func doCmdAdd(args *skel.CmdArgs, n *NetConf, fenv *subnetEnv) error {
 	return delegateAdd(args.ContainerID, n.DataDir, n.Delegate)
 }
 
-func doCmdDel(args *skel.CmdArgs, n *NetConf) (err error) {
+func doCmdDel(args *skel.CmdArgs, n *NetConf) error {
 	cleanup, netConfBytes, err := consumeScratchNetConf(args.ContainerID, n.DataDir)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/flannel_linux_test.go
+++ b/flannel_linux_test.go
@@ -67,12 +67,6 @@ var _ = Describe("Flannel", func() {
 
 	const inputIPAMType = "my-ipam"
 
-	const inputIPAMNoTypeTemplate = `
-{
-    "unknown-param": "unknown-value",
-    "routes": [%s]%s
-}`
-
 	const inputIPAMRoutes = `
       { "dst": "10.96.0.0/12" },
       { "dst": "192.168.244.0/24", "gw": "10.1.17.20" }`


### PR DESCRIPTION
Lint tools found two issues:
* We are defining the return variable as (err error)
* const inputIPAMNoTypeTemplate =  is not being used