### PR TITLE
set CGO_ENABLED=1 when GOARCH=amd64

### DIFF
--- a/scripts/build_flannel.sh
+++ b/scripts/build_flannel.sh
@@ -31,8 +31,8 @@ STATIC_FLAGS='-extldflags "-static"'
 
 GO_LDFLAGS="${STATIC_FLAGS} ${EXTRA_LDFLAGS}"
 
-if [ -z "${CGO_ENABLED}" ]; then
-  CGO_ENABLED="${CGO_ENABLED}"
+if [ ${GOARCH} == "amd64" ]; then
+  CGO_ENABLED="1"
 else
   CGO_ENABLED=0
 fi


### PR DESCRIPTION
When moving to the new muti-arch build method, we accidentally removed setting `CGO_ENABLED=1` when the architecture is amd64.
This was set in the Makefile which is not called in the new build process so this PR corrects the mistake.