### PR TITLE
Bump Go version

### DIFF
--- a/.github/workflows/buildTests.yaml
+++ b/.github/workflows/buildTests.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ "1.21.9" ]
+        go: [ "1.21.11" ]
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ on:
       - created
 
 env:
-  GO_VERSION: "1.21.9"
+  GO_VERSION: "1.21.11"
   REPOSITORY: flannel/flannel-cni-plugin
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ else
 endif
 
 # Go version to use for builds. Can be overridden
-GOLANG_VERSION?=1.21.9
+GOLANG_VERSION?=1.21.11
 
 build_all: vendor build_all_linux build_windows
 	@echo "All arches should be built for $(TAG)"


### PR DESCRIPTION
@manuelbuil 
```
flannel (gobinary)

Total: 3 (UNKNOWN: 0, LOW: 0, MEDIUM: 1, HIGH: 1, CRITICAL: 1)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬──────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                            Title                             │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼──────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-24790 │ CRITICAL │ fixed  │ 1.22.2            │ 1.21.11, 1.22.4 │ golang: net/netip: Unexpected behavior from Is methods for   │
│         │                │          │        │                   │                 │ IPv4-mapped IPv6 addresses                                   │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24790                   │
│         ├────────────────┼──────────┤        │                   ├─────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2024-24788 │ HIGH     │        │                   │ 1.22.3          │ golang: net: malformed DNS message can cause infinite loop   │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24788                   │
│         ├────────────────┼──────────┤        │                   ├─────────────────┼──────────────────────────────────────────────────────────────┤
│         │ CVE-2024-24789 │ MEDIUM   │        │                   │ 1.21.11, 1.22.4 │ golang: archive/zip: Incorrect handling of certain ZIP files │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24789                   │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴──────────────────────────────────────────────────────────────┘
```