### PR TITLE
Simplify build and make sure build info are coherent

### DIFF
--- a/Dockerfile.image
+++ b/Dockerfile.image
@@ -1,20 +1,16 @@
 FROM --platform=$BUILDPLATFORM tonistiigi/xx AS xx
 
-FROM --platform=$BUILDPLATFORM golang:alpine AS build
+FROM --platform=$BUILDPLATFORM golang:1.24.9-alpine3.22 AS build
 # copy xx scripts to your build stage
 COPY --from=xx / /
-ARG TARGETPLATFORM
-ARG BUILDPLATFORM
-RUN apk --no-cache add bash
-COPY go.mod go.sum *.go /build/
-COPY scripts /build/scripts
-WORKDIR /build
-RUN xx-info env
-RUN go mod tidy && go mod vendor
-RUN export GOOS=$(xx-info os) &&\
-    export GOARCH=$(xx-info arch) &&\
-    ./scripts/build_flannel.sh &&\
-    mv ./dist/flannel-${GOARCH} /flannel
+ARG TARGETARCH
+RUN apk --no-cache add bash make git
+WORKDIR /go/src/github.com/flannel-io/cni-plugin
+RUN --mount=type=bind,readwrite,target=/go/src/github.com/flannel-io/cni-plugin \
+    go mod tidy && go mod vendor
+RUN --mount=type=bind,readwrite,target=/go/src/github.com/flannel-io/cni-plugin \
+    ARCH=${TARGETARCH} make build_linux &&\
+    mv ./dist/flannel-${TARGETARCH} /flannel
 
 FROM alpine:20250108
 ARG GOARCH

--- a/flannel.go
+++ b/flannel.go
@@ -43,10 +43,9 @@ const (
 )
 
 var (
-	Program   string
-	Version   string
-	Commit    string
-	buildDate string
+	Program string
+	Version string
+	Commit  string
 )
 
 type NetConf struct {
@@ -326,7 +325,7 @@ func cmdDel(args *skel.CmdArgs) error {
 }
 
 func main() {
-	fullVer := fmt.Sprintf("CNI Plugin %s version %s (%s/%s) commit %s built on %s", Program, Version, runtime.GOOS, runtime.GOARCH, Commit, buildDate)
+	fullVer := fmt.Sprintf("CNI Plugin %s version %s (%s/%s) commit %s", Program, Version, runtime.GOOS, runtime.GOARCH, Commit)
 	skel.PluginMain(cmdAdd, cmdCheck, cmdDel, cni.All, fullVer)
 }
 

--- a/scripts/build_flannel.sh
+++ b/scripts/build_flannel.sh
@@ -22,7 +22,6 @@ VERSION_FLAGS="
     -X main.Version=${VERSION}
     -X main.Commit=${COMMIT:0:8}
     -X main.Program=${PROG:-flannel}
-    -X main.buildDate=${BUILD_DATE}
 "
 # STATIC_FLAGS='-linkmode external -extldflags "-static"'
 #STATIC_FLAGS='-extldflags "-static -Wl,--fatal-warnings"'

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -26,9 +26,8 @@ if [ -z "$GOOS" ]; then
     fi
 fi
 
-GIT_TAG=${TAG}
+GIT_TAG=$(git describe --tags --dirty --always)
 TREE_STATE=clean
-BUILD_DATE=$(date -u "+%Y-%m-%dT%H:%M:%SZ")
 COMMIT=$(git rev-parse HEAD)$(if ! git diff --no-ext-diff --quiet --exit-code; then echo .dirty; fi)
 PLATFORM=${GOOS}-${GOARCH}
 RELEASE=${PROG}-${GOARCH}
@@ -37,25 +36,13 @@ VERSION=${VERSION:-v1.0.0}
 GOLANG_VERSION=${GOLANG_VERSION:-1.24.3}
 
 if [ -d .git ]; then
-    if [ -z "${GIT_TAG}" ]; then
-        GIT_TAG=$(git tag -l --contains HEAD | head -n 1)
-    fi
-    if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
-        DIRTY="-dirty"
-        TREE_STATE=dirty
-    fi
-
     COMMIT=$(git log -n3 --pretty=format:"%H %ae" | cut -f1 -d\  | head -1)
     if [ -z "${COMMIT}" ]; then
         COMMIT=$(git rev-parse HEAD || true)
     fi
 fi
 
-if [[ -n "${GIT_TAG}" ]]; then
-    VERSION=${GIT_TAG}
-else
-    VERSION="${VERSION}-dev+${COMMIT:0:8}$DIRTY"
-fi
+VERSION="${GIT_TAG:0:6}"
 
 if [ -z "${TAG}" ]; then
   TAG=${VERSION}


### PR DESCRIPTION
The released flannel binary and the one from the docker image should now display the same version message.

Ref: https://github.com/flannel-io/cni-plugin/issues/135