### PR TITLE
Bump alpine image to 3.22.2

### DIFF
--- a/Dockerfile.image
+++ b/Dockerfile.image
@@ -12,7 +12,7 @@ RUN --mount=type=bind,readwrite,target=/go/src/github.com/flannel-io/cni-plugin 
     ARCH=${TARGETARCH} make build_linux &&\
     mv ./dist/flannel-${TARGETARCH} /flannel
 
-FROM alpine:20250108
+FROM alpine:3.22.2
 ARG GOARCH
 COPY --from=build /flannel /flannel
 


### PR DESCRIPTION
The edge branch is not updated anymore and the main one now supports riscv64 so we can use it.


Ref: #138 