### PR TITLE
bump Go to 1.26

### DIFF
--- a/.github/workflows/buildTests.yaml
+++ b/.github/workflows/buildTests.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: [ "1.24.3" ]
+        go: [ "1.26.0" ]
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ on:
       - created
 
 env:
-  GO_VERSION: "1.24.3"
+  GO_VERSION: "1.26.0"
   REPOSITORY: flannel/flannel-cni-plugin
   IMAGE_NAME: flannel-io/flannel-cni-plugin
   REGISTRY: ghcr.io

--- a/Dockerfile.image
+++ b/Dockerfile.image
@@ -1,6 +1,6 @@
 FROM --platform=$BUILDPLATFORM tonistiigi/xx AS xx
 
-FROM --platform=$BUILDPLATFORM golang:1.25.7-alpine3.22 AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.0-alpine3.22 AS build
 # copy xx scripts to your build stage
 COPY --from=xx / /
 ARG TARGETARCH

--- a/Dockerfile.image
+++ b/Dockerfile.image
@@ -1,6 +1,6 @@
 FROM --platform=$BUILDPLATFORM tonistiigi/xx AS xx
 
-FROM --platform=$BUILDPLATFORM golang:1.26.0-alpine3.22 AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine3.22 AS build
 # copy xx scripts to your build stage
 COPY --from=xx / /
 ARG TARGETARCH

--- a/Dockerfile.image
+++ b/Dockerfile.image
@@ -1,6 +1,6 @@
 FROM --platform=$BUILDPLATFORM tonistiigi/xx AS xx
 
-FROM --platform=$BUILDPLATFORM golang:1.26.4-alpine3.22 AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine3.22 AS build
 # copy xx scripts to your build stage
 COPY --from=xx / /
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/flannel-io/cni-plugin
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/containernetworking/cni v1.3.0


### PR DESCRIPTION
Bump the Go toolchain version to 1.26 across the project to pick up the latest language features, standard library improvements, and security fixes.

**Changes:**
- `go.mod`: updated `go` directive to `1.26.0`
- `Dockerfile.image`: updated base image to `golang:1.26.0-alpine3.22`
- `.github/workflows/release.yml`: updated `GO_VERSION` env var to `1.26.0`
- `.github/workflows/buildTests.yaml`: updated matrix `go` version to `1.26.0`

> Note: verify that the `golang:1.26.0-alpine3.22` Docker image tag is available on Docker Hub, and adjust the Alpine suffix if a newer patch version ships with a different Alpine release.