### PR TITLE
build: upgrade to Go 1.26.5 / Alpine 3.24 and pin image SHA digests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-ARG GOLANG_VERSION
-FROM library/golang:${GOLANG_VERSION}-alpine AS build
+FROM library/golang:1.26.5-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS build
 ARG TAG
 RUN set -x \
     && apk --no-cache add \

--- a/Dockerfile.image
+++ b/Dockerfile.image
@@ -1,6 +1,6 @@
-FROM --platform=$BUILDPLATFORM tonistiigi/xx AS xx
+FROM --platform=$BUILDPLATFORM tonistiigi/xx@sha256:c64defb9ed5a91eacb37f96ccc3d4cd72521c4bd18d5442905b95e2226b0e707 AS xx
 
-FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine3.22 AS build
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine3.24@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS build
 # copy xx scripts to your build stage
 COPY --from=xx / /
 ARG TARGETARCH
@@ -12,7 +12,7 @@ RUN --mount=type=bind,readwrite,target=/go/src/github.com/flannel-io/cni-plugin 
     ARCH=${TARGETARCH} make build_linux &&\
     mv ./dist/flannel-${TARGETARCH} /flannel
 
-FROM alpine:3.24.1
+FROM alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 ARG GOARCH
 COPY --from=build /flannel /flannel
 

--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,6 @@ else
 	CGO_ENABLED=0
 endif
 
-# Go version to use for builds. Can be overridden
-GOLANG_VERSION?=1.24.3
-
 build_all: vendor build_all_linux build_windows
 	@echo "All arches should be built for $(TAG)"
 
@@ -42,7 +39,6 @@ vendor:
 build_all_docker: vendor
 	docker build \
 		--no-cache \
-		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
 		--build-arg TAG=$(TAG) \
 		--tag $(REGISTRY):$(TAG) \
 		--tag $(REGISTRY):$(TAG)-$(ARCH) \


### PR DESCRIPTION
Pinning base images by SHA digest prevents silent supply-chain drift -- if an image tag is updated upstream, the build breaks loudly rather than silently pulling a different image.

## What changed

**`Dockerfile`** (release builder)
- Removed the `ARG GOLANG_VERSION` indirection; the Go version is now hardcoded directly in the `FROM` line.
- Bumped Go from `1.24.3` to `1.26.5`.
- Pinned `golang:1.26.5-alpine` with its SHA256 digest.

**`Dockerfile.image`** (runtime image builder)
- Bumped the Go build stage from `golang:1.26.5-alpine3.22` to `golang:1.26.5-alpine3.24`.
- Changed the final stage from `alpine:3.24.1` (patch tag) to `alpine:3.24` (minor tag) -- consistent with how the golang image is referenced -- and pinned it by digest.
- Pinned `tonistiigi/xx` by digest as well.

**`Makefile`**
- Removed the `GOLANG_VERSION` variable and the `--build-arg GOLANG_VERSION=...` from `build_all_docker`, since the version is now baked into the Dockerfile.